### PR TITLE
Remove mayavi dependency and build with newer numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ os: osx
 env:
   matrix:
     
-    - CONDA_PY=27
+    - CONDA_NPY=110  CONDA_PY=27
+    - CONDA_NPY=111  CONDA_PY=27
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "jbrYRP5M8YSP5FFaRyPrpSZzvQhEhq/fm2yhnkNjScAs9+8HY3pPLFyU49ON820EIdNrhPY+kDVCZhi9G98EYNqdKpnBuk9Oot8XVLiTUMQPyTKqUV54uPMej689ij50oItta6Vqm0wAO5dAcEREE/QoygEbne4WQksjQ8Ax/kHX563xl/PwJ0ob3p9l3DC6nNgt7bRsd28OrXICjMH+khFFhcevl6nKq4T2I1HEBjShikt/7FpeOOh4Q4icK1eUQkmLaWLsYM50+a5QSAy7UrEdGeoJdBpEQyILs+Glvgz9JrQ+mcsExHhnpzLRwxdHi/6/IRSMdcU8CZTU7O9a/9t7044eMII8OxODty7twZlJvrx1F90uvnqIMimC+WiC5azQemJ8rTf8JGxN2y5rStoLdGK4fFdw/zNc/KxkuaauCqsSlqxHny+4kStwxgqH/IGIMPML8V8VaiE/WqRCPywHb36nuCKwAj7GC3pijIgI8sLHNpd09hdeswZjE385Jvy1lxL9ayH9DBkMnbBfxKsmNJ6GzuYzLBAbVPVx8ONkvsOYU1EkAgPmRUtVcZgCcTN4Dv5RoOSBLJVndwkDOedu1/Vah/F/tGxHQvEe5X7niw6CZ2ZgYWpNxzrDye9T72fq6KzxsR3Yw9Cz6aXYL9W1vP+m4KBrI4p+KAz1qrM="

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,19 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
+      CONDA_NPY: 110
       CONDA_PY: 27
 
     - TARGET_ARCH: x64
+      CONDA_NPY: 110
+      CONDA_PY: 27
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 111
+      CONDA_PY: 27
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 111
       CONDA_PY: 27
 
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,8 +41,16 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 1 case(s).
+# Embarking on 2 case(s).
     set -x
+    export CONDA_NPY=110
+    export CONDA_PY=27
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=111
     export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,23 +12,22 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install
   skip: True  # [py3k]
 
 requirements:
   build:
     - python
-    - numpy 1.9.*
+    - numpy x.x
   run:
     - python
     - future
-    - numpy 1.9.*
+    - numpy x.x
     - scipy
     - matplotlib
     - numba
     - pillow
-    - mayavi
 
 test:
   imports:


### PR DESCRIPTION
Fixes #1 

Will use the `no-mayavi` branch to build versions of Fatiando with newer numpy that don't depend on Mayavi.
