### PR TITLE
Add back Python 2.7 in the build matrix for TravisCI and CircleCI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 
 build_artefacts
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ os: osx
 osx_image: beta-xcode6.1
 
 env:
+  matrix:
+    - CONDA_PY=27
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "jbrYRP5M8YSP5FFaRyPrpSZzvQhEhq/fm2yhnkNjScAs9+8HY3pPLFyU49ON820EIdNrhPY+kDVCZhi9G98EYNqdKpnBuk9Oot8XVLiTUMQPyTKqUV54uPMej689ij50oItta6Vqm0wAO5dAcEREE/QoygEbne4WQksjQ8Ax/kHX563xl/PwJ0ob3p9l3DC6nNgt7bRsd28OrXICjMH+khFFhcevl6nKq4T2I1HEBjShikt/7FpeOOh4Q4icK1eUQkmLaWLsYM50+a5QSAy7UrEdGeoJdBpEQyILs+Glvgz9JrQ+mcsExHhnpzLRwxdHi/6/IRSMdcU8CZTU7O9a/9t7044eMII8OxODty7twZlJvrx1F90uvnqIMimC+WiC5azQemJ8rTf8JGxN2y5rStoLdGK4fFdw/zNc/KxkuaauCqsSlqxHny+4kStwxgqH/IGIMPML8V8VaiE/WqRCPywHb36nuCKwAj7GC3pijIgI8sLHNpd09hdeswZjE385Jvy1lxL9ayH9DBkMnbBfxKsmNJ6GzuYzLBAbVPVx8ONkvsOYU1EkAgPmRUtVcZgCcTN4Dv5RoOSBLJVndwkDOedu1/Vah/F/tGxHQvEe5X7niw6CZ2ZgYWpNxzrDye9T72fq6KzxsR3Yw9Cz6aXYL9W1vP+m4KBrI4p+KAz1qrM="

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -42,6 +42,9 @@ conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
 # Embarking on 1 case(s).
+    set -x
+    export CONDA_PY=27
+    set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 EOF


### PR DESCRIPTION
As suggested by @ocefpaf, conda smithy had removed the environment configuration from `ci_support/run_docker_build.sh` and `.travis.yml`.